### PR TITLE
Escalate permissions via `become: yes` per task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,13 @@
     url: "https://cisofy.com/files/lynis-{{ lynis_version }}.tar.gz"
     dest: "{{ lynis_src_directory }}/lynis-{{ lynis_version }}.tar.gz"
     sha256sum: "{{ lynis_version_sha256sum }}"
+  become: yes
 
 - name: Ensure Lynis src directory exists.
   file:
     path: "{{ lynis_src_directory }}/lynis-{{ lynis_version }}"
     state: directory
+  become: yes
 
 - name: Extract Lynis.
   unarchive:
@@ -18,6 +20,7 @@
     dest: "{{ lynis_src_directory }}/lynis-{{ lynis_version }}"
     creates: "{{ lynis_src_directory }}/lynis-{{ lynis_version }}/lynis"
     copy: no
+  become: yes
 
 - name: Copy Lynis to dest directory.
   shell: >
@@ -25,6 +28,7 @@
     {{ lynis_src_directory }}/lynis-{{ lynis_version }}/lynis/
     {{ lynis_dest_directory }}/lynis
     | awk '{print $1}' | grep -vE '..\.\..\.\.\.\.' | wc -l
+  become: yes
   register: lynis_rsync
   changed_when: lynis_rsync.stdout|int != 0
 
@@ -32,9 +36,8 @@
   file:
     path: "{{ lynis_log_directory }}"
     state: directory
-    owner: root
-    group: root
     mode: 0750
+  become: yes
   when: lynis_cron
 
 - name: Configure Lynis cron task (when lynis_cron).
@@ -45,4 +48,5 @@
     hour: "{{ lynis_cron_hour }}"
     user: root
     job: cd {{ lynis_dest_directory }}/lynis && ./lynis -c --auditor "automated" --cronjob > {{ lynis_log_directory }}/report-$(hostname).$(date +%Y%m%d).txt && mv /var/log/lynis.log {{ lynis_log_directory }}/report-log-$(hostname).$(date +%Y%m%d).log && mv /var/log/lynis-report.dat {{ lynis_log_directory }}/report-data-$(hostname).$(date +%Y%m%d).txt >/dev/null 2>&1
+  become: yes
   when: lynis_cron


### PR DESCRIPTION
#### Because:

* Roles should not assume `become: yes` is set.