### PR TITLE
Update default lynis version to 2.4.0 (latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Role Variables
 --------------
 
 ```yml
-lynis_version: 2.1.1
-lynis_version_sha256sum: d17b3cbbd305c52b9cd0d5141f41954882f398db44f26c10cb45fdaaa46a99d2
+lynis_version: 2.4.0
+lynis_version_sha256sum: 4bda6fb87674c7f402564351b142fcda6b5397b66d0d7edb6a8f0d46a70de5ab
 ```
 The version and corresponding `sha256sum` of Lynis to install. Latest version and hash can be found on the [Lynis download page](https://cisofy.com/download/lynis/).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for lynis
 
-lynis_version: 2.1.1
-lynis_version_sha256sum: d17b3cbbd305c52b9cd0d5141f41954882f398db44f26c10cb45fdaaa46a99d2
+lynis_version: 2.4.0
+lynis_version_sha256sum: 4bda6fb87674c7f402564351b142fcda6b5397b66d0d7edb6a8f0d46a70de5ab
 
 lynis_src_directory: /usr/local/src
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Copy Lynis to dest directory.
   shell: >
-    rsync --delete -ri --exclude="plugins/*"
+    rsync --delete -ri --links --exclude="plugins/*"
     {{ lynis_src_directory }}/lynis-{{ lynis_version }}/lynis/
     {{ lynis_dest_directory }}/lynis
     | awk '{print $1}' | grep -vE '..\.\..\.\.\.\.' | wc -l


### PR DESCRIPTION
#### Because:

* 2.1.1 is now a little out of date.

#### This change:

* Updates default lynis version and checksum to 2.4.0.
* Sets `--links` option on rsync as 2.4.0 now includes some local
  symlinks in the language config that should be copied across.