### PR TITLE
Fix `-c` deprecation warning in cron task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,6 @@
     minute: "{{ lynis_cron_minute }}"
     hour: "{{ lynis_cron_hour }}"
     user: root
-    job: cd {{ lynis_dest_directory }}/lynis && ./lynis -c --auditor "automated" --cronjob > {{ lynis_log_directory }}/report-$(hostname).$(date +%Y%m%d).txt && mv /var/log/lynis.log {{ lynis_log_directory }}/report-log-$(hostname).$(date +%Y%m%d).log && mv /var/log/lynis-report.dat {{ lynis_log_directory }}/report-data-$(hostname).$(date +%Y%m%d).txt >/dev/null 2>&1
+    job: cd {{ lynis_dest_directory }}/lynis && ./lynis audit system --auditor "automated" --cronjob > {{ lynis_log_directory }}/report-$(hostname).$(date +%Y%m%d).txt && mv /var/log/lynis.log {{ lynis_log_directory }}/report-log-$(hostname).$(date +%Y%m%d).log && mv /var/log/lynis-report.dat {{ lynis_log_directory }}/report-data-$(hostname).$(date +%Y%m%d).txt >/dev/null 2>&1
   become: yes
   when: lynis_cron


### PR DESCRIPTION
#### Because:

* Using `-c` gives the following deprecation warning in 2.4.0:

```
[TIP]: Usage of option -c is deprecated. Please use: lynis audit system [options]
```

#### This change:

* Adjusts the cron task to use the new API.