### PR TITLE
Fix `-c` deprecation warning in travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
     || (echo 'Idempotence test: fail' && exit 1)
 
   # Check to make sure the Lynis runs.
-  - cd /opt/lynis && sudo ./lynis -c --auditor "test" --cronjob
+  - cd /opt/lynis && sudo ./lynis audit system --auditor "test" --cronjob
 
   # Check to make sure Lynis cron job is present.
   - "cat /etc/cron.d/lynis | grep -q 'Ansible: Run Lynis'"


### PR DESCRIPTION
#### Because:

* Using `-c` gives the following deprecation warning in 2.4.0:

```
[TIP]: Usage of option -c is deprecated. Please use: lynis audit system
```