### PR TITLE
Download Lynis from https://downloads.cisofy.com/lynis/lynis-

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Download Lynis.
   get_url:
-    url: "https://cisofy.com/files/lynis-{{ lynis_version }}.tar.gz"
+    url: "https://downloads.cisofy.com/lynis/lynis-{{ lynis_version }}.tar.gz"
     dest: "{{ lynis_src_directory }}/lynis-{{ lynis_version }}.tar.gz"
     sha256sum: "{{ lynis_version_sha256sum }}"
   become: yes


### PR DESCRIPTION
Hi,

Related to #12. 

The Lynis download url seems to have changed, making this role non-functional. The correction is simple, just change the url parameter of the Lynis Download task to : 

"https://downloads.cisofy.com/lynis/lynis-{{lynis_version }}.tar.gz"